### PR TITLE
Waiting

### DIFF
--- a/myplugin/content/api_endpoints.py
+++ b/myplugin/content/api_endpoints.py
@@ -2,8 +2,8 @@
 # Base URL for the Backend API
 #BASE_URL = "http://141.72.12.222:8000/api/"
 #BASE_URL = "http://141.72.12.173:8000/api/"
-BASE_URL = "http://localhost:8000/api/"
-#BASE_URL = "http://141.72.12.209:8000/api/"
+#BASE_URL = "http://localhost:8000/api/"
+BASE_URL = "http://141.72.12.209:8000/api/"
 
 # Define your API endpoints in a dictionary or as constants
 API_ENDPOINTS = {

--- a/myplugin/content/api_endpoints.py
+++ b/myplugin/content/api_endpoints.py
@@ -2,8 +2,8 @@
 # Base URL for the Backend API
 #BASE_URL = "http://141.72.12.222:8000/api/"
 #BASE_URL = "http://141.72.12.173:8000/api/"
-#BASE_URL = "http://localhost:8000/api/"
-BASE_URL = "http://141.72.12.209:8000/api/"
+BASE_URL = "http://localhost:8000/api/"
+#BASE_URL = "http://141.72.12.209:8000/api/"
 
 # Define your API endpoints in a dictionary or as constants
 API_ENDPOINTS = {

--- a/myplugin/content/eduvmstore/templates/eduvmstore/details.html
+++ b/myplugin/content/eduvmstore/templates/eduvmstore/details.html
@@ -118,20 +118,35 @@
             <strong>App-Template ID:</strong>
             <p>{{ app_template.id }}</p>
         </div>
+        <div class="detail-group">
+            <strong>Created at:</strong>
+            <p>{{ app_template.created_at }}</p>
+        </div>
     </div>
     <div class="col-md-6">
         <div class="detail-group">
-            <strong>Image ID:</strong>
+            <strong>Available for:</strong>
             <p>
-                <a href="/dashboard/ngdetails/OS::Glance::Image/{{ app_template.image_id }}/" class="template-link">
-                    {{ app_template.image_id }}
-                </a>
+                {% if app_template.public and app_template.approve %}
+                    Everyone
+                {% elif app_template.public and not app_template.approve %}
+                    Waiting for approval
+                {% elif not app_template.public and not app_template.approve %}
+                    Creator only
+                {% endif %}
             </p>
+
         </div>
         <div class="detail-group">
             <strong>Short Description:</strong>
             <p>{{ app_template.short_description }}</p>
         </div>
+
+        <div class="detail-group">
+            <strong>App Template Creator:</strong>
+            <p>{{ app_template_creator }}</p>
+        </div>
+
     </div>
 </div>
 
@@ -192,15 +207,12 @@
     <div class="row">
         <div class="col-md-6">
             <div class="detail-group">
-                <strong>Available for:</strong>
+                <strong>Image ID:</strong>
                 <p>
-                    {% if app_template.public %}
-                    Everyone
-                {% else %}
-                    Creator only
-                {% endif %}
+                    <a href="/dashboard/ngdetails/OS::Glance::Image/{{ app_template.image_id }}/" class="template-link">
+                        {{ app_template.image_id }}
+                    </a>
                 </p>
-
             </div>
         </div>
         <div class="col-md-6">
@@ -209,12 +221,7 @@
                 <p>{{ image_owner }}</p>
             </div>
         </div>
-        <div class="col-md-6">
-            <div class="detail-group">
-                <strong>Created at:</strong>
-                <p>{{ image_created_at }}</p>
-            </div>
-        </div>
+
     </div>
 </div>
 

--- a/myplugin/content/eduvmstore/templates/eduvmstore/details.html
+++ b/myplugin/content/eduvmstore/templates/eduvmstore/details.html
@@ -127,11 +127,11 @@
         <div class="detail-group">
             <strong>Available for:</strong>
             <p>
-                {% if app_template.public and app_template.approve %}
+                {% if app_template.public and app_template.approved %}
                     Everyone
-                {% elif app_template.public and not app_template.approve %}
+                {% elif app_template.public and not app_template.approved %}
                     Waiting for approval
-                {% elif not app_template.public and not app_template.approve %}
+                {% elif not app_template.public and not app_template.approved %}
                     Creator only
                 {% endif %}
             </p>

--- a/myplugin/content/eduvmstore/templates/eduvmstore/details.html
+++ b/myplugin/content/eduvmstore/templates/eduvmstore/details.html
@@ -137,15 +137,18 @@
             </p>
 
         </div>
-        <div class="detail-group">
-            <strong>Short Description:</strong>
-            <p>{{ app_template.short_description }}</p>
-        </div>
 
         <div class="detail-group">
             <strong>App Template Creator:</strong>
             <p>{{ app_template_creator }}</p>
         </div>
+
+        <div class="detail-group">
+            <strong>Short Description:</strong>
+            <p>{{ app_template.short_description }}</p>
+        </div>
+
+
 
     </div>
 </div>

--- a/myplugin/content/eduvmstore/templates/eduvmstore/details.html
+++ b/myplugin/content/eduvmstore/templates/eduvmstore/details.html
@@ -120,7 +120,7 @@
         </div>
         <div class="detail-group">
             <strong>Created at:</strong>
-            <p>{{ app_template.created_at }}</p>
+            <p>{{ created_at }}</p>
         </div>
     </div>
     <div class="col-md-6">

--- a/myplugin/content/eduvmstore/templates/eduvmstore/table.html
+++ b/myplugin/content/eduvmstore/templates/eduvmstore/table.html
@@ -23,11 +23,13 @@
             <td>{{ app_template.short_description }}</td>
             <td>{{ app_template.size }} </td>
            <td>
-                {% if app_template.public %}
-                    Everyone
-                {% else %}
-                    Creator only
-                {% endif %}
+               {% if app_template.public and app_template.approve %}
+                   Everyone
+               {% elif app_template.public and not app_template.approve %}
+                   Waiting for approval
+               {% elif not app_template.public and not app_template.approve %}
+                   Creator only
+               {% endif %}
             </td>
               <td>
     <div class="btn-group">

--- a/myplugin/content/eduvmstore/templates/eduvmstore/table.html
+++ b/myplugin/content/eduvmstore/templates/eduvmstore/table.html
@@ -23,11 +23,11 @@
             <td>{{ app_template.short_description }}</td>
             <td>{{ app_template.size }} </td>
            <td>
-               {% if app_template.public and app_template.approve %}
+               {% if app_template.public and app_template.approved %}
                    Everyone
-               {% elif app_template.public and not app_template.approve %}
+               {% elif app_template.public and not app_template.approved %}
                    Waiting for approval
-               {% elif not app_template.public and not app_template.approve %}
+               {% elif not app_template.public and not app_template.approved %}
                    Creator only
                {% endif %}
             </td>

--- a/myplugin/content/eduvmstore/views.py
+++ b/myplugin/content/eduvmstore/views.py
@@ -317,7 +317,7 @@ class DetailsPageView(generic.TemplateView):
             user = keystone.user_get(self.request, user_id)
             return user.name
         except Exception:
-            return 'Unbekannt'
+            return user_id
 
 
     def get_app_template(self):

--- a/myplugin/content/eduvmstore/views.py
+++ b/myplugin/content/eduvmstore/views.py
@@ -302,7 +302,7 @@ class DetailsPageView(generic.TemplateView):
         owner_id = image_data.get('owner', '')
         image_owner_id = owner_id.replace('-', '')
         image_owner_name = (
-            self.get_username_from_id(image_owner_id)
+            self.get_project_name_from_id(image_owner_id)
             if image_owner_id else 'N/A'
         )
 
@@ -322,6 +322,13 @@ class DetailsPageView(generic.TemplateView):
             return user.name
         except Exception:
             return user_id
+
+    def get_project_name_from_id(self, project_id):
+        try:
+            project = keystone.project_get(self.request, project_id)
+            return project.name
+        except Exception:
+            return project_id
 
 
     def get_app_template(self):

--- a/myplugin/content/eduvmstore/views.py
+++ b/myplugin/content/eduvmstore/views.py
@@ -295,13 +295,13 @@ class DetailsPageView(generic.TemplateView):
 
         app_template_creator_id = app_template.get('creator_id', '')
         app_template_creator_name = (
-            self.get_username_from_id(self.request, app_template_creator_id)
+            self.get_username_from_id(app_template_creator_id)
             if app_template_creator_id else 'N/A'
         )
 
         image_owner_id = image_data.get('owner', '')
         image_owner_name = (
-            self.get_username_from_id(self.request, image_owner_id)
+            self.get_username_from_id(image_owner_id)
             if image_owner_id else 'N/A'
         )
 
@@ -314,11 +314,12 @@ class DetailsPageView(generic.TemplateView):
 
         return context
 
-    def get_username_from_id(request, user_id):
-        session = auth_utils.get_session(request)
+    def get_username_from_id(self, user_id):
+        session = auth_utils.get_session(self.request)
         keystone = keystone_client.Client(session=session)
         user = keystone.users.get(user_id)
         return user.name
+
 
     def get_app_template(self):
         """

--- a/myplugin/content/eduvmstore/views.py
+++ b/myplugin/content/eduvmstore/views.py
@@ -10,6 +10,7 @@ from django.urls import reverse_lazy
 from horizon import tabs, exceptions
 from openstack_dashboard import api
 from openstack_dashboard.api import glance, nova, cinder, keystone
+from openstack_auth.api import keystone as auth_keystone
 from django.views import generic
 from myplugin.content.eduvmstore.forms import AppTemplateForm, InstanceForm
 from django.utils.translation import gettext_lazy as _
@@ -324,7 +325,7 @@ class DetailsPageView(generic.TemplateView):
             return user_id
 
     def get_project_name_from_id(self, project_id):
-        project = keystone.project_get(self.request, project_id)
+        project = auth_keystone.project_get(self.request, project_id)
         return project.name
 
 

--- a/myplugin/content/eduvmstore/views.py
+++ b/myplugin/content/eduvmstore/views.py
@@ -313,11 +313,8 @@ class DetailsPageView(generic.TemplateView):
         return context
 
     def get_username_from_id(self, user_id):
-        try:
-            user = keystone.user_get(self.request, user_id)
-            return user.name
-        except Exception:
-            return user_id
+        user = keystone.user_get(self.request, user_id)
+        return user.name
 
 
     def get_app_template(self):

--- a/myplugin/content/eduvmstore/views.py
+++ b/myplugin/content/eduvmstore/views.py
@@ -299,11 +299,10 @@ class DetailsPageView(generic.TemplateView):
             if app_template_creator_id else 'N/A'
         )
 
-        owner_id = image_data.get('owner', '')
         context.update({
             'app_template': app_template,
             'image_visibility': image_data.get('visibility', 'N/A'),
-            'image_owner': owner_id,
+            'image_owner': image_data.get('owner', 'N/A'),
             'app_template_creator': app_template_creator_name,
             'created_at': created_at,
         })

--- a/myplugin/content/eduvmstore/views.py
+++ b/myplugin/content/eduvmstore/views.py
@@ -315,7 +315,7 @@ class DetailsPageView(generic.TemplateView):
         return context
 
     def get_username_from_id(self, user_id):
-        session = auth_utils.get_session()
+        session = auth_utils.get_session(self.request)
         keystone = keystone_client.Client(session=session)
         user = keystone.users.get(user_id)
         return user.name

--- a/myplugin/content/eduvmstore/views.py
+++ b/myplugin/content/eduvmstore/views.py
@@ -324,11 +324,8 @@ class DetailsPageView(generic.TemplateView):
             return user_id
 
     def get_project_name_from_id(self, project_id):
-        try:
-            project = keystone.project_get(self.request, project_id)
-            return project.name
-        except Exception:
-            return project_id
+        project = keystone.project_get(self.request, project_id)
+        return project.name
 
 
     def get_app_template(self):

--- a/myplugin/content/eduvmstore/views.py
+++ b/myplugin/content/eduvmstore/views.py
@@ -10,7 +10,6 @@ from django.urls import reverse_lazy
 from horizon import tabs, exceptions
 from openstack_dashboard import api
 from openstack_dashboard.api import glance, nova, cinder, keystone
-from openstack_auth.api import keystone as auth_keystone
 from django.views import generic
 from myplugin.content.eduvmstore.forms import AppTemplateForm, InstanceForm
 from django.utils.translation import gettext_lazy as _
@@ -301,16 +300,10 @@ class DetailsPageView(generic.TemplateView):
         )
 
         owner_id = image_data.get('owner', '')
-        image_owner_id = owner_id.replace('-', '')
-        image_owner_name = (
-            self.get_project_name_from_id(image_owner_id)
-            if image_owner_id else 'N/A'
-        )
-
         context.update({
             'app_template': app_template,
             'image_visibility': image_data.get('visibility', 'N/A'),
-            'image_owner': image_owner_name,
+            'image_owner': owner_id,
             'app_template_creator': app_template_creator_name,
             'created_at': created_at,
         })
@@ -324,9 +317,6 @@ class DetailsPageView(generic.TemplateView):
         except Exception:
             return user_id
 
-    def get_project_name_from_id(self, project_id):
-        project = auth_keystone.project_get(self.request, project_id)
-        return project.name
 
 
     def get_app_template(self):

--- a/myplugin/content/eduvmstore/views.py
+++ b/myplugin/content/eduvmstore/views.py
@@ -315,7 +315,7 @@ class DetailsPageView(generic.TemplateView):
         return context
 
     def get_username_from_id(self, user_id):
-        session = auth_utils.get_session(self.request)
+        session = auth_utils.get_session()
         keystone = keystone_client.Client(session=session)
         user = keystone.users.get(user_id)
         return user.name

--- a/myplugin/content/eduvmstore/views.py
+++ b/myplugin/content/eduvmstore/views.py
@@ -317,8 +317,11 @@ class DetailsPageView(generic.TemplateView):
         return context
 
     def get_username_from_id(self, user_id):
-        user = keystone.user_get(self.request, user_id)
-        return user.name
+        try:
+            user = keystone.user_get(self.request, user_id)
+            return user.name
+        except Exception:
+            return user_id
 
 
     def get_app_template(self):

--- a/myplugin/content/eduvmstore/views.py
+++ b/myplugin/content/eduvmstore/views.py
@@ -9,8 +9,7 @@ from django.shortcuts import render, redirect
 from django.urls import reverse_lazy
 from horizon import tabs, exceptions
 from openstack_dashboard import api
-from openstack_dashboard.api import glance, nova, cinder
-from openstack_auth.api import keystone
+from openstack_dashboard.api import glance, nova, cinder, keystone
 from django.views import generic
 from myplugin.content.eduvmstore.forms import AppTemplateForm, InstanceForm
 from django.utils.translation import gettext_lazy as _

--- a/myplugin/content/eduvmstore/views.py
+++ b/myplugin/content/eduvmstore/views.py
@@ -292,13 +292,15 @@ class DetailsPageView(generic.TemplateView):
         image_data = self.get_image_data(app_template.get('image_id', ''))
         created_at = app_template.get('created_at', '').split('T')[0]
 
-        app_template_creator_id = app_template.get('creator_id', '')
+        creator_id = app_template.get('creator_id', '')
+        app_template_creator_id = creator_id.replace('-', '')
         app_template_creator_name = (
             self.get_username_from_id(app_template_creator_id)
             if app_template_creator_id else 'N/A'
         )
 
-        image_owner_id = image_data.get('owner', '')
+        owner_id = image_data.get('owner', '')
+        image_owner_id = owner_id.replace('-', '')
         image_owner_name = (
             self.get_username_from_id(image_owner_id)
             if image_owner_id else 'N/A'

--- a/myplugin/content/eduvmstore/views.py
+++ b/myplugin/content/eduvmstore/views.py
@@ -290,6 +290,7 @@ class DetailsPageView(generic.TemplateView):
         context = super().get_context_data(**kwargs)
         app_template = self.get_app_template()
         image_data = self.get_image_data(app_template.get('image_id', ''))
+        created_at = app_template.get('created_at', '').split('T')[0]
 
         app_template_creator_id = app_template.get('creator_id', '')
         app_template_creator_name = (
@@ -308,6 +309,7 @@ class DetailsPageView(generic.TemplateView):
             'image_visibility': image_data.get('visibility', 'N/A'),
             'image_owner': image_owner_name,
             'app_template_creator': app_template_creator_name,
+            'created_at': created_at,
         })
 
         return context


### PR DESCRIPTION
* neue Anordnung in App Template Details: teilweise waren App Template Details unter Image Information und Image Details unter App Template Details
* zusätzlicher Status: waiting for approval: wenn apptemplate public aber nicht approved dann wird als visibility status nicht everyone sondern waiting for approval angezeigt
* statt creator_id wird name des creators angezeigt - funktioniert über Keystone, haben halt jz sowohl im backend als auch im frontend eine Anbindung von Keystone, finde es aber unnötig hierfür einen eigenen endpoint im backend zu schreiben, der aus einer creator id einen creator namen macht, gerne aber eure Meinungen @rickertmar  @val-cze 

zur Info: bei Image wird weiterhin die Owner Id angezeigt, da der owner von einem image kein user ist sondern ein project der owner ist, heißt das ist die project id, die angezeigt wird, für die Umwandlung von project id in project name benötigt es eine andere api, bei der aber ein wunderschöner internal server error kommt, wenn ich die aufrufe. wir haben ja aber das image verlinkt worüber dann zusätzlich die infos abgerufen werden können